### PR TITLE
fix: update tagline to Agentic Engineering Blog

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,4 +1,4 @@
-# Coder Rocks — The Agentic Coding Hub
+# Coder Rocks — The Agentic Engineering Blog
 
 > Coder Rocks is a technical content hub focused on AI-assisted development, autonomous coding agents, and modern software engineering.
 

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,7 +1,7 @@
 export const Settings = {
   site: {
     title: 'CoderRocks',
-    tagline: 'The Agentic Coding Hub',
+    tagline: 'The Agentic Engineering Blog',
     gaTagId: '',
     mainUrl: 'https://coder.rocks',
     secondUrl: 'https://CoderRocks.com',
@@ -11,7 +11,7 @@ export const Settings = {
 
   brand: {
     name: 'Coder Rocks',
-    tagline: 'The Agentic Coding Hub',
+    tagline: 'The Agentic Engineering Blog',
     foundingDate: '2020',
     logo: '/images/social.png',
   },


### PR DESCRIPTION
## Summary
- Updated site tagline from "The Agentic Coding Hub" to "The Agentic Engineering Blog" in site config and llms.txt

## Test plan
- Verify tagline renders correctly on homepage