### PR TITLE
fix: make hero image mandatory in submit guidelines

### DIFF
--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -120,7 +120,7 @@ const seoDescription =
             </div>
             <div class="ml-4">
               └── hero.jpg&nbsp;&nbsp;&nbsp;&nbsp;<span class="text-zinc-400"
-                ># cover image (optional, &lt;400kb)</span
+                ># cover image (required, &lt;400kb)</span
               >
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Changed hero.jpg from "optional" to "required" in post structure on submit page

## Test plan
- Verify `/submit` post structure shows "required" for hero.jpg