### PR TITLE
fix: increase line-height on h2/h3 for multiline headings

### DIFF
--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -18,7 +18,7 @@
   }
 
   h2 {
-    @apply py-6 text-2xl leading-none font-semibold;
+    @apply py-6 text-2xl leading-snug font-semibold;
 
     @variant sm {
       @apply text-2xl;
@@ -33,7 +33,7 @@
   }
 
   h3 {
-    @apply py-4 text-xl leading-6 font-semibold;
+    @apply py-4 text-xl leading-snug font-semibold;
   }
 
   h4 {


### PR DESCRIPTION
## Summary
- h2: `leading-none` (1.0) → `leading-snug` (1.375)
- h3: `leading-6` (1.5rem) → `leading-snug` (1.375)

Fixes cluttered multiline headings in blog posts.

## Test plan
- Verify multiline headings on `/posts/claude-opus-4-6-transition-from-opus-4-5` have proper spacing