### PR TITLE
fix: resolve og:image for Twitter card previews

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -7,7 +7,7 @@ import type { Props as AuthorProps } from '@component/Footer/PostFooter.astro'
 import { fetchAuthor } from '@request/fetchAuthor'
 import blogSlugToLegendImageData from '@layouts/BlogHero'
 import { getCollection, render } from 'astro:content'
-import type { InferGetStaticPropsType } from 'astro'
+import type { InferGetStaticPropsType, ImageMetadata } from 'astro'
 import { blogPostingJsonLd, breadcrumbJsonLd } from '@utils/jsonld'
 
 export const prerender = true
@@ -29,8 +29,10 @@ const { title, description, pubDate, youtube, author, tags } = post.data
 const slug = post.id.replace(/\/index$/, '')
 
 const legendImage = blogSlugToLegendImageData(slug)
-
-const ogImage = `/posts/${slug}/hero.jpg`
+const resolvedImage = (await legendImage) as unknown as
+  | ImageMetadata
+  | undefined
+const ogImage = resolvedImage?.src || '/images/social.png'
 
 const userAgent = 'cr-engine@v1.0.0'
 


### PR DESCRIPTION
## Summary
- The `og:image` and `twitter:image` meta tags were hardcoded to `/posts/{slug}/hero.jpg`, a path that doesn't exist in the build output — Vite hashes assets into `/_astro/`
- Now resolves the actual image path from the glob import used by `BlogHero.ts`, so Twitter/OG previews show the correct hero image
- Falls back to `/images/social.png` for posts without a hero image

## Test plan
- [x] `yarn build` succeeds
- [x] `yarn test` — 82 tests pass
- [x] Verified `og:image` in built HTML points to `/_astro/hero.xxx.jpg` for posts with hero images
- [x] Verified fallback to `/images/social.png` for posts without hero images