### PR TITLE
fix: serve og:image from static /og/ path for social previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "astro:build": "astro build",
-    "build": "npm run pub-code:clean && npm run pub-code:link && npm run astro:build && npx pagefind --site dist",
+    "build": "npm run pub-code:clean && npm run pub-code:link && npm run astro:build && node scripts/copy-og-images.js && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "rmdir": "node -e \"var fs = require('fs');process.argv.slice(1).map((fpath)=>{ try { fs.rmdirSync(fpath,{recursive: true})} catch(e){console.warn('[ WARNING ] : Folder not found -', fpath)} });process.exit(0);\"",

--- a/scripts/copy-og-images.js
+++ b/scripts/copy-og-images.js
@@ -1,0 +1,22 @@
+const fs = require('fs')
+const path = require('path')
+
+const postsDir = path.join(__dirname, '..', 'src', 'content', 'posts')
+const ogDir = path.join(__dirname, '..', 'dist', 'og')
+
+if (!fs.existsSync(postsDir)) process.exit(0)
+
+fs.mkdirSync(ogDir, { recursive: true })
+
+for (const slug of fs.readdirSync(postsDir)) {
+  const postDir = path.join(postsDir, slug)
+  if (!fs.statSync(postDir).isDirectory()) continue
+
+  for (const ext of ['jpg', 'png']) {
+    const src = path.join(postDir, `hero.${ext}`)
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, path.join(ogDir, `${slug}.${ext}`))
+      break
+    }
+  }
+}

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -32,7 +32,9 @@ const legendImage = blogSlugToLegendImageData(slug)
 const resolvedImage = (await legendImage) as unknown as
   | ImageMetadata
   | undefined
-const ogImage = resolvedImage?.src || '/images/social.png'
+const ogImage = resolvedImage
+  ? `/og/${slug}.${resolvedImage.format}`
+  : '/images/social.png'
 
 const userAgent = 'cr-engine@v1.0.0'
 


### PR DESCRIPTION
## Summary
- Cloudflare bot protection blocks crawler access to Vite-hashed `/_astro/` image paths, causing broken Twitter/Facebook card previews
- Adds a post-build step (`scripts/copy-og-images.js`) that copies hero images to `dist/og/{slug}.{ext}`
- Updates `og:image`/`twitter:image` meta tags to reference `/og/{slug}.{ext}` instead of `/_astro/` paths

## Test plan
- [x] `yarn build` succeeds, hero images copied to `dist/og/`
- [x] `yarn test` — 82 tests pass
- [x] `og:image` in built HTML points to `/og/{slug}.{ext}` for all posts with hero images
- [x] Posts without hero images fall back to `/images/social.png`