### PR TITLE
feat: auto-tweet new blog posts on deploy

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -57,3 +57,14 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=coder-rocks
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tweet new posts
+        if: >-
+          github.event_name == 'repository_dispatch' &&
+          github.event.client_payload.new_posts != ''
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_SECRET: ${{ secrets.X_ACCESS_SECRET }}
+        run: node scripts/tweet-new-post.mjs "${{ github.event.client_payload.new_posts }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,28 @@ yarn pub-code:clean         # Remove content directory
 
 `@utils/*`, `@config/*`, `@component/*`, `@layouts/*`, `@request/*` (restapi), `@pages/*`
 
+## Content Repo (`coder-rocks`)
+
+The blog content lives in a separate repo: [`nirus/coder-rocks`](https://github.com/nirus/coder-rocks).
+
+- **Default branch**: `publish`
+- **Local path**: `/Volumes/aryabhata/workspace/coder-rocks`
+- **Structure**: each post is a directory with `claim.json`, `index.md`, and optional `hero.jpg`/`hero.png`
+- **Deploy trigger**: pushing to `publish` fires `.github/workflows/trigger-build.yaml`, which sends a `repository_dispatch` (`content-update`) to `cr-engine` using the `CR_ENGINE_TRIGGER_TOKEN` PAT
+- **During build**: `scripts/cr-repo-connect/build.sh` clones `coder-rocks` into `src/content/posts/` via sparse checkout
+
+### Adding a new post
+
+1. Create a directory in `coder-rocks` with the post slug
+2. Add `claim.json` (title, description, pubDate, tags, author), `index.md`, and `hero.jpg`
+3. Push/merge to `publish` — cr-engine deploys automatically
+
 ## Deployment
 
 - **Cloudflare Pages free tier has limited deployments per day.** Batch all related changes into a single PR and merge once — do not create separate PRs for each small change.
 - Every push to `main` triggers a deploy via GitHub Actions (`pages-deployment.yaml`).
 - The content repo (`coder-rocks`) also triggers deploys via `repository_dispatch`.
+- **OG images**: `plugins/CopyOgImages/index.mjs` copies hero images to `dist/og/{slug}.{ext}` at build time for social card previews (Cloudflare blocks crawler access to Vite-hashed `/_astro/` paths).
 
 ## Conventions
 
@@ -72,6 +89,49 @@ yarn pub-code:clean         # Remove content directory
 - **Images**: Relative paths (`./image.png`), hero images auto-detected per post
 - **Pagination**: 21 posts per page
 - **SSR**: Only `/preview` route — everything else is static
+
+## PR Rules
+
+- **One PR per logical change.** Batch related fixes into a single PR — Cloudflare free tier has limited daily deploys.
+- **All PRs must pass CI** before merging: lint, format check, tests, build.
+- **Squash merge only** to keep `main` history clean.
+- **Delete branch after merge** (auto-enabled in repo settings).
+- **Dependabot PRs** auto-merge when CI passes. Do not manually merge Dependabot PRs that have failing checks.
+- **Never force-push to `main`.**
+- **PR titles** follow conventional commits: `feat:`, `fix:`, `chore:`, `build:`, `docs:`.
+- **PR descriptions** must include a `## Summary` and `## Test plan` section.
+
+## Lint Rules
+
+ESLint enforces these rules (pre-commit hook + CI):
+
+- **`curly: 'error'`** — always use braces on `if`/`else`/`for`/`while`. Never write `if (x) return`.
+- **`@typescript-eslint/consistent-type-assertions: never`** — do not use `as` type casts. Use type guards (`instanceof`, `in`, narrowing) instead. If unavoidable, add `eslint-disable-next-line` with a comment explaining why.
+- **Lint-staged order**: ESLint runs first, then Prettier formats the result.
+
+## Security
+
+### Secrets — never commit these
+
+| Secret | Where it lives | Purpose |
+|--------|---------------|---------|
+| `CLOUDFLARE_API_TOKEN` | GitHub repo secrets | Cloudflare Pages deploy |
+| `CLOUDFLARE_ACCOUNT_ID` | GitHub repo secrets | Cloudflare account |
+| `GITHUB_TOKEN` | GitHub auto-provided | CI workflows |
+| `GA_TAG_ID` | GitHub repo variables | Google Analytics |
+| `SITE` | GitHub repo secrets | Site configuration |
+| `CR_ENGINE_TRIGGER_TOKEN` | `coder-rocks` repo secrets | Cross-repo deploy dispatch |
+
+### Rules
+
+- **Never commit `.env`, `.dev.vars`, API keys, tokens, or credentials.** These are already in `.gitignore`.
+- **Never log secrets** in CI output, console.log, or error messages.
+- **Never put secrets in URL parameters** — they leak in server logs and referrer headers.
+- **Never hardcode secrets in source code.** Use `import.meta.env` for environment variables.
+- **Review CI workflow changes carefully** — `pages-deployment.yaml` has access to all deploy secrets.
+- **PATs (Personal Access Tokens)** must be scoped to the minimum required permissions and stored as GitHub secrets, never in code.
+- **Dependabot PRs** that modify `package.json`, `yarn.lock`, or CI workflows should be reviewed for supply chain risks before merging.
+- **Third-party Actions** in workflows must be pinned to a specific version (e.g., `actions/checkout@v3`), not `@latest`.
 
 ## Troubleshooting
 

--- a/scripts/tweet-new-post.mjs
+++ b/scripts/tweet-new-post.mjs
@@ -1,0 +1,132 @@
+import { createHmac, randomBytes } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+const SITE_URL = 'https://coder.rocks'
+const API_URL = 'https://api.x.com/2/tweets'
+
+const { X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_SECRET } = process.env
+
+const slugs = (process.argv[2] || '').split(',').filter(Boolean)
+
+if (slugs.length === 0) {
+  console.log('No new posts to tweet')
+  process.exit(0)
+}
+
+if (!X_API_KEY || !X_API_SECRET || !X_ACCESS_TOKEN || !X_ACCESS_SECRET) {
+  console.error('Missing X API credentials in environment')
+  process.exit(1)
+}
+
+/**
+ * Generate OAuth 1.0a signature for the X API
+ */
+function oauthSign(method, url, params) {
+  const signatureBase = [
+    method.toUpperCase(),
+    encodeURIComponent(url),
+    encodeURIComponent(
+      Object.keys(params)
+        .sort()
+        .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
+        .join('&'),
+    ),
+  ].join('&')
+
+  const signingKey = `${encodeURIComponent(X_API_SECRET)}&${encodeURIComponent(X_ACCESS_SECRET)}`
+  return createHmac('sha1', signingKey).update(signatureBase).digest('base64')
+}
+
+/**
+ * Build OAuth 1.0a Authorization header
+ */
+function oauthHeader(method, url) {
+  const oauthParams = {
+    oauth_consumer_key: X_API_KEY,
+    oauth_nonce: randomBytes(16).toString('hex'),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_token: X_ACCESS_TOKEN,
+    oauth_version: '1.0',
+  }
+
+  oauthParams.oauth_signature = oauthSign(method, url, oauthParams)
+
+  const header = Object.keys(oauthParams)
+    .sort()
+    .map(
+      k => `${encodeURIComponent(k)}="${encodeURIComponent(oauthParams[k])}"`,
+    )
+    .join(', ')
+
+  return `OAuth ${header}`
+}
+
+/**
+ * Compose tweet text from claim.json metadata
+ */
+function composeTweet(slug, claim) {
+  const title = claim.title || slug
+  const description = claim.description || ''
+  const tags = (claim.tags || [])
+    .slice(0, 4)
+    .map(t => `#${t.replace(/\s+/g, '')}`)
+    .join(' ')
+  const url = `${SITE_URL}/posts/${slug}`
+
+  let tweet = `${title}\n\n${description}\n\n${tags}\n${url}`
+
+  // X counts URLs as ~23 chars. Trim description if over 280.
+  if (tweet.length > 280) {
+    const available = 280 - title.length - tags.length - 23 - 8 // newlines + buffer
+    const trimmed = description.slice(0, Math.max(0, available)) + '...'
+    tweet = `${title}\n\n${trimmed}\n\n${tags}\n${url}`
+  }
+
+  return tweet
+}
+
+/**
+ * Post a tweet via X API v2
+ */
+async function postTweet(text) {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: oauthHeader('POST', API_URL),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text }),
+  })
+
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(`X API error ${response.status}: ${JSON.stringify(data)}`)
+  }
+  return data
+}
+
+// Process each new post
+for (const slug of slugs) {
+  const claimPath = `src/content/posts/${slug}/claim.json`
+  let claim
+  try {
+    claim = JSON.parse(readFileSync(claimPath, 'utf8'))
+  } catch {
+    console.log(`Skipping ${slug} — claim.json not found`)
+    continue
+  }
+
+  const tweet = composeTweet(slug, claim)
+  console.log(`Tweeting for: ${slug}`)
+  console.log(tweet)
+  console.log('---')
+
+  try {
+    const result = await postTweet(tweet)
+    console.log(`Posted: https://x.com/Coder_Rocks/status/${result.data.id}`)
+  } catch (err) {
+    console.error(`Failed to tweet for ${slug}:`, err.message)
+    // Don't fail the build if tweeting fails
+  }
+}


### PR DESCRIPTION
## Summary
- Add `scripts/tweet-new-post.mjs` — posts to X API v2 with OAuth 1.0a signing (zero external deps)
- Add tweet step in CI after deploy, only on `repository_dispatch` with new post slugs
- Update CLAUDE.md with PR rules, lint rules, security guidelines, and content repo docs

## How it works
1. `coder-rocks` trigger detects new `claim.json` files via `git diff --diff-filter=A`
2. Passes slugs in `repository_dispatch` payload to cr-engine
3. After successful deploy, tweet script reads `claim.json` and posts: title + description + hashtags + URL

## Test plan
- [x] `yarn lint` passes
- [x] Script exits cleanly with empty slugs
- [x] OAuth 1.0a signing uses built-in `crypto` (no deps)
- [ ] End-to-end: push new post to coder-rocks, verify tweet appears on @Coder_Rocks