### PR TITLE
fix: make X handle configurable via env var

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -67,4 +67,5 @@ jobs:
           X_API_SECRET: ${{ secrets.X_API_SECRET }}
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
           X_ACCESS_SECRET: ${{ secrets.X_ACCESS_SECRET }}
+          X_HANDLE: ${{ vars.X_HANDLE }}
         run: node scripts/tweet-new-post.mjs "${{ github.event.client_payload.new_posts }}"

--- a/scripts/tweet-new-post.mjs
+++ b/scripts/tweet-new-post.mjs
@@ -1,7 +1,8 @@
 import { createHmac, randomBytes } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 
-const SITE_URL = 'https://coder.rocks'
+const SITE_URL = process.env.SITE_URL || 'https://coder.rocks'
+const X_HANDLE = process.env.X_HANDLE || 'Coder_Rocks'
 const API_URL = 'https://api.x.com/2/tweets'
 
 const { X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_SECRET } = process.env
@@ -124,7 +125,7 @@ for (const slug of slugs) {
 
   try {
     const result = await postTweet(tweet)
-    console.log(`Posted: https://x.com/Coder_Rocks/status/${result.data.id}`)
+    console.log(`Posted: https://x.com/${X_HANDLE}/status/${result.data.id}`)
   } catch (err) {
     console.error(`Failed to tweet for ${slug}:`, err.message)
     // Don't fail the build if tweeting fails


### PR DESCRIPTION
## Summary
- `X_HANDLE` and `SITE_URL` in tweet script are now configurable via environment
- `X_HANDLE` passed from `vars.X_HANDLE` in workflow (set via GitHub repo variables)
- Defaults to `Coder_Rocks` and `https://coder.rocks` if not set

## Test plan
- [x] `yarn lint` passes