### PR TITLE
fix: skip deploy for chore/ci/docs commits

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -50,7 +50,26 @@ jobs:
           GA_TAG_ID: ${{vars.GA_TAG_ID}}
         run: yarn build
 
+      - name: Check if deploy is needed
+        id: should-deploy
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            MSG="${{ github.event.head_commit.message }}"
+            case "$MSG" in
+              chore:*|chore\(*|build\(deps\)*|ci:*|ci\(*|docs:*|docs\(*)
+                echo "deploy=false" >> "$GITHUB_OUTPUT"
+                echo "Skipping deploy for: $MSG"
+                ;;
+              *)
+                echo "deploy=true" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          fi
+
       - name: Deploy
+        if: steps.should-deploy.outputs.deploy == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -60,6 +79,7 @@ jobs:
 
       - name: Tweet new posts
         if: >-
+          steps.should-deploy.outputs.deploy == 'true' &&
           github.event_name == 'repository_dispatch' &&
           github.event.client_payload.new_posts != ''
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ The blog content lives in a separate repo: [`nirus/coder-rocks`](https://github.
 ## Deployment
 
 - **Cloudflare Pages free tier has limited deployments per day.** Batch all related changes into a single PR and merge once — do not create separate PRs for each small change.
-- Every push to `main` triggers a deploy via GitHub Actions (`pages-deployment.yaml`).
-- The content repo (`coder-rocks`) also triggers deploys via `repository_dispatch`.
+- Every push to `main` triggers CI (lint, format, test, build). **Deploy only runs for `feat:` and `fix:` commits.**
+- **`chore:`, `build(deps):`, `ci:`, `docs:` commits skip deploy** — they still run the full CI pipeline but don't consume a Cloudflare deployment. Changes are picked up on the next `feat:`/`fix:` deploy.
+- The content repo (`coder-rocks`) always triggers a deploy via `repository_dispatch`.
 - **OG images**: `plugins/CopyOgImages/index.mjs` copies hero images to `dist/og/{slug}.{ext}` at build time for social card previews (Cloudflare blocks crawler access to Vite-hashed `/_astro/` paths).
+- **Auto-tweet**: new blog posts are announced on @Coder_Rocks after deploy (`scripts/tweet-new-post.mjs`).
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- `feat:` and `fix:` commits trigger full deploy to Cloudflare Pages
- `chore:`, `build(deps):`, `ci:`, `docs:` commits run CI (lint/test/build) but skip deploy
- `repository_dispatch` (content updates) always deploys
- Conserves Cloudflare free tier daily deploy limit

## Test plan
- [x] Commit with `chore:` prefix → deploy step skipped
- [x] Commit with `feat:` prefix → deploy runs
- [x] `repository_dispatch` → always deploys