### PR TITLE
fix: remove trailing slash from blog URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,9 @@ export default defineConfig({
     service: passthroughImageService(),
   },
   trailingSlash: 'never',
+  build: {
+    format: 'file',
+  },
   integrations: [
     sitemap({
       changefreq: 'weekly',


### PR DESCRIPTION
## Summary
- Set `build.format: 'file'` in astro.config.mjs
- Astro now outputs `slug.html` instead of `slug/index.html`
- Cloudflare Pages won't add trailing slash redirect when there's no directory

## Test plan
- [x] `yarn build` — outputs `dist/posts/slug.html` format
- [x] `yarn test` — 82 tests pass
- [x] Pagefind indexes 5 pages