### PR TITLE
chore: update CI actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -72,7 +72,7 @@ jobs:
 
       - name: Deploy
         if: steps.should-deploy.outputs.deploy == 'true'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- `actions/checkout` v3 -> v4 (Node.js 20 -> 22)
- `cloudflare/wrangler-action` v3 -> v3.14.1 (pinned)
- `actions/cache@v4` already on Node.js 22

Fixes: "Node.js 20 actions are deprecated" warning

## Test plan
- [x] No logic changes — action version bumps only