### PR TITLE
feat: dark theme as default with neutral editorial palette

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,8 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1752867944457
-	},
-	"devToolbar": {
-		"enabled": false
+		"lastUpdateCheck": 1774698279842
 	}
 }

--- a/.nvimlog
+++ b/.nvimlog
@@ -1,0 +1,1 @@
+WRN 2026-03-28T10:37:55.366 ?.47908    server_start:199: Failed to start server: operation not permitted: /var/folders/nn/nhj1bcw11jz8k6_c_p10fl740000gn/T/nvim.nirus/w5TrLi/nvim.47908.0

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -53,7 +53,8 @@ Navigate to the deployment URL and verify these pages:
 | `/sitemap-index.xml` | Sitemap generation |
 
 Also verify:
-- Dark mode toggle (bottom-right floating button) persists across navigation
+- Dark mode is the default for new visitors (no localStorage)
+- Light mode opt-in via floating icon (bottom-right) works and persists
 - No FOUC (flash of unstyled content) on page load
 
 ## Cloudflare Access Authentication
@@ -101,4 +102,256 @@ gh run view <run-id> --log 2>&1 | grep "claim-json-loader\|UnknownContentCollect
 
 ```bash
 git push origin --delete demo/my-feature
+```
+
+---
+
+# Feature Preview on Cloudflare Before Merge
+
+End-to-end process for previewing a feature branch on Cloudflare Pages before merging to `main`.
+
+## How It Works
+
+The CI workflow (`.github/workflows/pages-deployment.yaml`) triggers on pushes to `main` and `demo/**` branches. Pushing to a `demo/**` branch runs the full pipeline — lint, format, test, build, deploy — producing a preview URL on Cloudflare Pages without touching production.
+
+### CI Pipeline Steps
+
+```
+Install → Lint → Format check → Test → Build → Deploy check → Deploy
+```
+
+- **Lint**: `yarn lint` (ESLint)
+- **Format**: `yarn prettier --check` (Prettier, check-only — no writes)
+- **Test**: `yarn test` (Vitest)
+- **Build**: `yarn build` (clean → link content → astro build → pagefind)
+- **Deploy check**: `feat:` and `fix:` commits deploy; `chore:`, `docs:`, `ci:`, `build(deps):` skip deploy but still run the full CI pipeline
+- **Deploy**: `wrangler pages deploy dist` to Cloudflare Pages
+
+## Step-by-Step
+
+### 1. Create a feature branch and commit
+
+```bash
+git checkout -b feat/dark-theme-default
+# ... make changes ...
+git add <files>
+git commit -m "feat: make dark theme default"
+```
+
+### 2. Push to a demo branch
+
+This triggers the CI workflow and Cloudflare deploy:
+
+```bash
+git push origin feat/dark-theme-default:demo/dark-theme-default
+```
+
+The `demo/` prefix is what triggers the workflow — your local branch name doesn't matter.
+
+### 3. Monitor the CI run
+
+```bash
+# Find the run
+gh run list --branch demo/dark-theme-default --limit 1
+
+# Watch it live
+gh run watch <run-id>
+```
+
+### 4. Get the preview URL
+
+```bash
+gh run view <run-id> --log 2>&1 | grep "Deployment complete"
+```
+
+Two URLs are available:
+- **Hash URL**: `https://<hash>.coder-rocks.pages.dev` (unique per deploy)
+- **Branch alias**: `https://demo-dark-theme-default.coder-rocks.pages.dev` (updates on each push)
+
+### 5. Test the preview
+
+Open the preview URL in a browser. Preview deployments are behind **Cloudflare Access** — sign in when prompted.
+
+**If Cloudflare Access blocks you**, test locally instead:
+
+```bash
+# Build locally with the same pipeline as CI
+yarn build
+
+# Serve with Cloudflare Workers runtime
+yarn preview:cf
+# Open http://localhost:8787
+```
+
+### 6. Iterate
+
+Push more commits to your feature branch, then update the demo branch:
+
+```bash
+# After committing more changes on your feature branch
+git push origin feat/dark-theme-default:demo/dark-theme-default
+```
+
+Each push triggers a fresh CI run and updates the branch alias URL.
+
+### 7. Create the PR
+
+Once the preview looks good:
+
+```bash
+# Push the feature branch itself
+git push origin feat/dark-theme-default
+
+# Create the PR
+gh pr create --title "feat: make dark theme default" --body "..."
+```
+
+PR title must follow conventional commits (`feat:`, `fix:`, etc.). CI runs again on the PR branch — all checks must pass before merge.
+
+### 8. Clean up the demo branch
+
+```bash
+git push origin --delete demo/dark-theme-default
+```
+
+## Deploy Behavior Reference
+
+| Commit prefix | CI runs? | Deploys to Cloudflare? |
+|---------------|----------|------------------------|
+| `feat:` | Yes | Yes |
+| `fix:` | Yes | Yes |
+| `chore:` | Yes | No (skipped) |
+| `docs:` | Yes | No (skipped) |
+| `ci:` | Yes | No (skipped) |
+| `build(deps):` | Yes | No (skipped) |
+| `repository_dispatch` | Yes | Yes (always) |
+
+**Important**: Cloudflare Pages free tier has limited daily deploys. Batch related changes into a single commit/push rather than pushing repeatedly.
+
+## Troubleshooting Preview Deploys
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| CI passes but no deploy | Commit message starts with `chore:`, `docs:`, etc. | Use `feat:` or `fix:` prefix |
+| Preview URL shows old version | Browser cache | Hard-reload (`Cmd+Shift+R`) or use incognito |
+| Cloudflare Access blocks you | Preview domains require auth | Sign in, or use `yarn build && yarn preview:cf` locally |
+| Deploy step skipped in logs | `should-deploy` check returned false | Check commit message — only `feat:`/`fix:` trigger deploy |
+| Branch alias URL 404 | Branch name has special chars | Keep demo branch names to `[a-z0-9-]` |
+
+---
+
+# Local Development & Testing
+
+Quick reference for running, testing, and iterating locally using `package.json` scripts.
+
+## 1. Setup Content
+
+Blog content lives in a separate repo and must be linked before the site works:
+
+```bash
+# Clone content into src/content/posts/ (sparse checkout)
+yarn pub-code:link
+
+# If content gets stale, reset it
+yarn pub-code:clean && yarn pub-code:link
+
+# Pull latest content without re-cloning
+yarn pub-code:refresh
+```
+
+## 2. Dev Server
+
+```bash
+yarn dev          # Starts Astro dev server (http://localhost:4321)
+```
+
+- Hot-reloads on file changes (components, styles, layouts, pages)
+- Content changes (claim.json, index.md) also trigger reload
+- Dev server uses mock author data (no GitHub API calls)
+
+## 3. Run Tests
+
+```bash
+yarn test          # Single run (Vitest)
+yarn test:watch    # Re-runs on file changes
+yarn test:ui       # Browser-based test dashboard
+```
+
+Tests are co-located with source files (`*.test.ts`). Key test suites:
+
+| File | What it covers |
+|------|----------------|
+| `src/utils/theme.test.ts` | Theme toggle, localStorage, default preference |
+| `src/utils/help.test.ts` | GitHub username regex, YouTube URL helper |
+| `src/utils/preview/validation.test.ts` | URL allowlist, slug sanitization |
+| `src/restapi/fetchAuthor.test.ts` | Author API fetch, regex guard |
+| `src/content.config.test.ts` | claim.json loader, schema validation |
+
+## 4. Lint & Format
+
+```bash
+yarn lint          # Check for ESLint errors
+yarn lint:fix      # Auto-fix ESLint errors
+yarn prettier:write  # Format all source files
+```
+
+Lint-staged runs automatically on `git commit` (ESLint first, then Prettier).
+
+## 5. Full Production Build
+
+```bash
+yarn build         # clean → link content → astro build → pagefind index
+```
+
+This runs the complete pipeline:
+1. `pub-code:clean` — removes `src/content/posts/`
+2. `pub-code:link` — clones fresh content
+3. `astro:build` — generates static site in `dist/`
+4. `pagefind --site dist` — builds search index
+
+## 6. Preview the Production Build
+
+```bash
+yarn preview       # Astro's built-in preview (http://localhost:4321)
+yarn preview:cf    # Wrangler Pages dev server (http://localhost:8787)
+```
+
+Use `preview:cf` to test with Cloudflare Workers runtime (closer to production).
+
+## 7. Testing Theme Changes
+
+After modifying dark/light mode behavior:
+
+1. **Run unit tests** — `yarn test` (covers `theme.ts` logic)
+2. **Start dev server** — `yarn dev`
+3. **Check in browser:**
+
+| What to verify | How |
+|----------------|-----|
+| Default theme is dark | Open `http://localhost:4321` in a private/incognito window (no localStorage) |
+| Light mode opt-in | Click the floating sun icon (bottom-right) — page should switch to light |
+| Preference persists | Reload the page — should stay on whichever theme you chose |
+| No FOUC | Hard-reload (`Cmd+Shift+R`) — no white flash before dark theme applies |
+| Icon state | Dark mode shows sun icon, light mode shows moon icon |
+
+4. **Clear stored preference** to re-test default:
+   - Open DevTools → Application → Local Storage → delete `theme-preference`
+   - Reload — should default back to dark
+
+## 8. Common Workflow: Change → Test → Verify
+
+```bash
+# 1. Make your code changes
+
+# 2. Run tests
+yarn test
+
+# 3. Check lint
+yarn lint
+
+# 4. Start dev server and verify in browser
+yarn dev
+
+# 5. (Optional) Full build + preview to catch SSG issues
+yarn build && yarn preview:cf
 ```

--- a/src/components/Content/BlogPost.astro
+++ b/src/components/Content/BlogPost.astro
@@ -32,7 +32,7 @@ const parsedDay = dayjs(pubDate).format('LL')
   </h1>
 </header>
 <article
-  class="post mx-auto max-w-5xl p-3 lg:rounded-lg lg:border-2 lg:border-stone-200 dark:lg:border-slate-600"
+  class="post mx-auto max-w-5xl p-3 lg:rounded-lg lg:border-2 lg:border-stone-200 lg:shadow-[0_0_60px_10px_rgba(59,130,246,0.06),0_0_120px_40px_rgba(147,51,234,0.04)] dark:bg-neutral-950 dark:lg:border-neutral-800 dark:lg:shadow-[0_0_80px_15px_rgba(77,208,225,0.12),0_0_160px_50px_rgba(124,58,237,0.06)]"
 >
   <!-- Legend Image -->
   {

--- a/src/components/Content/Card.astro
+++ b/src/components/Content/Card.astro
@@ -40,7 +40,7 @@ const tags: string[] = post.data.tags || []
 
 <a
   href={`/posts/${slug}`}
-  class="group relative top-0 block h-full overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white shadow-lg transition-all duration-300 ease-in-out hover:-top-2 hover:border-sky-300 hover:shadow-xl dark:border-slate-600 dark:bg-slate-800"
+  class="group relative top-0 block h-full overflow-hidden rounded-xl border border-solid border-neutral-200 bg-white shadow-lg transition-all duration-300 ease-in-out hover:-top-2 hover:border-sky-300 hover:shadow-xl dark:border-neutral-800 dark:bg-neutral-900"
   data-test="article-card"
 >
   <Image
@@ -55,14 +55,16 @@ const tags: string[] = post.data.tags || []
     <h2 class="text-xl leading-normal font-normal">
       {post.data.title}
     </h2>
-    <p class="mt-4 flex items-center text-xs text-gray-600 dark:text-slate-400">
+    <p
+      class="mt-4 flex items-center text-xs text-gray-600 dark:text-neutral-400"
+    >
       {parsedDay}
     </p>
     {
       tags.length > 0 && (
         <div class="mt-3 flex flex-wrap gap-1.5">
           {tags.slice(0, 3).map(tag => (
-            <span class="rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs text-zinc-600 capitalize dark:bg-slate-700 dark:text-slate-300">
+            <span class="rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs text-zinc-600 capitalize dark:bg-neutral-800 dark:text-neutral-300">
               {tag}
             </span>
           ))}

--- a/src/components/Content/SearchInput.astro
+++ b/src/components/Content/SearchInput.astro
@@ -7,7 +7,7 @@
     <input
       type="text"
       id="searchBox"
-      class="searchBox w-full rounded-lg border-2 border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:outline-none dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-400"
+      class="searchBox w-full rounded-lg border-2 border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200 dark:placeholder-neutral-400"
       placeholder="Search articles..."
       data-test="search-input"
       autocomplete="off"
@@ -65,7 +65,7 @@
       if (!results.length) {
         const noResultsEl = document.createElement('div')
         noResultsEl.className =
-          'p-6 bg-gray-50 rounded-lg border border-gray-200 text-center dark:bg-slate-800 dark:border-slate-600'
+          'p-6 bg-gray-50 rounded-lg border border-gray-200 text-center dark:bg-neutral-900 dark:border-neutral-800'
         noResultsEl.innerHTML = `
           <div class="text-gray-500 mb-2">
             <svg class="w-12 h-12 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -83,7 +83,7 @@
       resultsContainer.className = 'space-y-4'
 
       const countEl = document.createElement('div')
-      countEl.className = 'text-sm text-gray-600 mb-4 dark:text-slate-400'
+      countEl.className = 'text-sm text-gray-600 mb-4 dark:text-neutral-400'
       countEl.textContent = `Found ${results.length} result${results.length !== 1 ? 's' : ''} for "${query}"`
       resultsContainer.appendChild(countEl)
 
@@ -93,11 +93,11 @@
       loaded.forEach(result => {
         const resultEl = document.createElement('div')
         resultEl.className =
-          'p-4 bg-white rounded-lg border border-gray-200 hover:border-blue-300 hover:shadow-md transition-all duration-200 dark:bg-slate-800 dark:border-slate-600 dark:hover:border-blue-500'
+          'p-4 bg-white rounded-lg border border-gray-200 hover:border-blue-300 hover:shadow-md transition-all duration-200 dark:bg-neutral-900 dark:border-neutral-800 dark:hover:border-blue-500'
 
         const titleEl = document.createElement('a')
         titleEl.className =
-          'block text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors duration-200 mb-2 dark:text-slate-100 dark:hover:text-blue-400'
+          'block text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors duration-200 mb-2 dark:text-neutral-200 dark:hover:text-blue-400'
         titleEl.href = result.url
         titleEl.textContent = result.meta?.title || 'Untitled'
         resultEl.appendChild(titleEl)
@@ -105,7 +105,7 @@
         if (result.excerpt) {
           const excerptEl = document.createElement('div')
           excerptEl.className =
-            'text-sm text-gray-600 leading-relaxed dark:text-slate-300'
+            'text-sm text-gray-600 leading-relaxed dark:text-neutral-300'
           excerptEl.innerHTML = result.excerpt
           resultEl.appendChild(excerptEl)
         }

--- a/src/components/Footer/PostFooter.astro
+++ b/src/components/Footer/PostFooter.astro
@@ -22,7 +22,7 @@ const {
 <footer
   class={`text-center ${Settings.post.contentWidth} mx-auto flex flex-col`}
 >
-  <div class="border-b-2 border-zinc-400 pt-4 dark:border-slate-600"></div>
+  <div class="border-b-2 border-zinc-400 pt-4 dark:border-neutral-800"></div>
 
   <div class="m-auto flex items-center">
     <img

--- a/src/components/Head/BaseHead.astro
+++ b/src/components/Head/BaseHead.astro
@@ -36,10 +36,10 @@ const gaTagId = import.meta.env.GA_TAG_ID || Settings.site.gaTagId
 const jsonLdArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : []
 ---
 
-<!-- Dark mode FOUC prevention -->
+<!-- Dark mode FOUC prevention — dark is default -->
 <script is:inline>
   ;(function () {
-    if (localStorage.getItem('theme-preference') === 'dark') {
+    if (localStorage.getItem('theme-preference') !== 'light') {
       document.documentElement.classList.add('dark')
     }
   })()

--- a/src/components/Navigation/ThemeToggle.astro
+++ b/src/components/Navigation/ThemeToggle.astro
@@ -5,7 +5,7 @@
 <button
   id="theme-toggle"
   type="button"
-  class="fixed right-6 bottom-6 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-zinc-300 bg-zinc-100 shadow-lg transition-colors hover:bg-zinc-200 dark:border-transparent dark:bg-zinc-700 dark:hover:bg-zinc-600"
+  class="fixed right-6 bottom-6 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-zinc-300 bg-zinc-100 shadow-lg transition-colors hover:bg-zinc-200 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:bg-neutral-800"
   aria-label="Toggle theme"
 >
   <!-- Sun icon (shown in dark mode — click to go light) -->
@@ -46,7 +46,7 @@
 
     function getStored() {
       var val = localStorage.getItem(STORAGE_KEY)
-      return val === 'dark' ? 'dark' : 'light'
+      return val === 'light' ? 'light' : 'dark'
     }
 
     function apply(pref) {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ const description = ''
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <Nav />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,13 +28,13 @@ const sortedPosts = allPosts
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <TopBarNav />
 
     <main
-      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-slate-900 dark:to-slate-900"
+      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-neutral-950 dark:to-neutral-950"
     >
       <article class="mx-auto max-w-6xl px-3">
         <HomeHead tagline={tagline} />
@@ -59,7 +59,7 @@ const sortedPosts = allPosts
       <a
         href="/posts"
         data-test="see-all-link"
-        class="m-2 border-b-2 border-b-white hover:border-b-gray-800 dark:border-b-slate-900 dark:hover:border-b-slate-200"
+        class="m-2 border-b-2 border-b-white hover:border-b-gray-800 dark:border-b-neutral-950 dark:hover:border-b-neutral-200"
       >
         View All &nbsp;&rarr;
       </a>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -40,36 +40,36 @@ const seoDescription =
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <TopBarNav />
 
     <main
-      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-slate-900 dark:to-slate-800"
+      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-neutral-950 dark:to-neutral-900"
     >
       <article class="mx-auto max-w-6xl px-4">
         <HomeHead showLogo={true} />
         <div class="mt-1 mb-8 flex items-center gap-4">
-          <div class="h-px flex-1 bg-zinc-200 dark:bg-slate-700"></div>
+          <div class="h-px flex-1 bg-zinc-200 dark:bg-neutral-800"></div>
           <div class="flex items-center gap-2.5">
             <span
-              class="text-base font-medium tracking-wider text-zinc-500 uppercase dark:text-slate-400"
+              class="text-base font-medium tracking-wider text-zinc-500 uppercase dark:text-neutral-400"
               >Articles</span
             >
             <span
-              class="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-sky-100 px-2 text-sm font-bold text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+              class="inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-sky-100 px-2 text-sm font-bold text-sky-700 dark:bg-cyan-900 dark:text-cyan-300"
               >{page.total}</span
             >
             {
               page.lastPage > 1 && (
-                <span class="text-xs text-zinc-400 dark:text-slate-500">
+                <span class="text-xs text-zinc-400 dark:text-neutral-500">
                   · pg {page.currentPage}/{page.lastPage}
                 </span>
               )
             }
           </div>
-          <div class="h-px flex-1 bg-zinc-200 dark:bg-slate-700"></div>
+          <div class="h-px flex-1 bg-zinc-200 dark:bg-neutral-800"></div>
         </div>
 
         <section

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -82,7 +82,7 @@ const articleMeta = {
     />
   </head>
 
-  <body class="dark:bg-slate-900 dark:text-slate-100">
+  <body class="dark:bg-neutral-950 dark:text-neutral-200">
     <TopBarNav />
     <main class="py-12" data-pagefind-body>
       <BlogPost

--- a/src/pages/preview.astro
+++ b/src/pages/preview.astro
@@ -29,7 +29,7 @@ const previewResult = await processPreviewUrl(urlParam, Astro.request)
   </head>
 
   <body
-    class="dark:bg-slate-900 dark:text-slate-100"
+    class="dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <TopBarNav />

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -18,7 +18,7 @@ const seoDescription =
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <TopNavBar />

--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -15,47 +15,47 @@ const seoDescription =
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <Nav />
     <main
-      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-slate-900 dark:to-slate-800"
+      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-neutral-950 dark:to-neutral-900"
     >
       <article class="mx-auto max-w-2xl px-4">
         <div class="mb-10 text-center">
           <h1
-            class="text-2xl font-semibold tracking-tight text-zinc-800 dark:text-slate-100"
+            class="text-2xl font-semibold tracking-tight text-zinc-800 dark:text-neutral-200"
           >
             Submit a Post
           </h1>
-          <p class="mt-2 text-zinc-500 dark:text-slate-400">
+          <p class="mt-2 text-zinc-500 dark:text-neutral-400">
             You and your coding agent solved something interesting? Write it up
             and share it with the world.
           </p>
         </div>
 
         <section
-          class="mb-10 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-slate-600 dark:bg-slate-800"
+          class="mb-10 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
         >
           <h2
-            class="mb-4 text-lg font-semibold text-zinc-800 dark:text-slate-100"
+            class="mb-4 text-lg font-semibold text-zinc-800 dark:text-neutral-200"
           >
             How it works
           </h2>
           <p
-            class="mb-4 text-sm leading-relaxed text-zinc-500 dark:text-slate-400"
+            class="mb-4 text-sm leading-relaxed text-zinc-500 dark:text-neutral-400"
           >
             Whether you pair-programmed with an AI agent or cracked a tough
             problem on your own — if the solution is worth sharing, we want it
             here.
           </p>
           <ol
-            class="space-y-3 text-sm leading-relaxed text-zinc-600 dark:text-slate-300"
+            class="space-y-3 text-sm leading-relaxed text-zinc-600 dark:text-neutral-300"
           >
             <li class="flex gap-3">
               <span
-                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-cyan-900 dark:text-cyan-300"
                 >1</span
               >
               <span
@@ -65,7 +65,7 @@ const seoDescription =
             </li>
             <li class="flex gap-3">
               <span
-                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-cyan-900 dark:text-cyan-300"
                 >2</span
               >
               <span
@@ -75,20 +75,20 @@ const seoDescription =
             </li>
             <li class="flex gap-3">
               <span
-                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-cyan-900 dark:text-cyan-300"
                 >3</span
               >
               <span
                 >Fork the <a
                   href="https://github.com/nirus/coder-rocks"
-                  class="font-medium text-sky-600 underline decoration-sky-300 hover:text-sky-700 dark:text-sky-400 dark:hover:text-sky-300"
+                  class="font-medium text-sky-600 underline decoration-sky-300 hover:text-sky-700 dark:text-cyan-400 dark:hover:text-cyan-300"
                   >coder-rocks</a
                 > content repo and add your post directory.</span
               >
             </li>
             <li class="flex gap-3">
               <span
-                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-sky-900 dark:text-sky-300"
+                class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-100 text-xs font-bold text-sky-700 dark:bg-cyan-900 dark:text-cyan-300"
                 >4</span
               >
               <span>Open a pull request — we review and publish.</span>
@@ -97,15 +97,15 @@ const seoDescription =
         </section>
 
         <section
-          class="mb-10 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-slate-600 dark:bg-slate-800"
+          class="mb-10 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
         >
           <h2
-            class="mb-4 text-lg font-semibold text-zinc-800 dark:text-slate-100"
+            class="mb-4 text-lg font-semibold text-zinc-800 dark:text-neutral-200"
           >
             Post structure
           </h2>
           <div
-            class="rounded-lg bg-zinc-50 p-4 font-mono text-xs leading-relaxed text-zinc-600 dark:bg-slate-900 dark:text-slate-400"
+            class="rounded-lg bg-zinc-50 p-4 font-mono text-xs leading-relaxed text-zinc-600 dark:bg-neutral-950 dark:text-neutral-400"
           >
             <div>your-post-slug/</div>
             <div class="ml-4">
@@ -127,15 +127,15 @@ const seoDescription =
         </section>
 
         <section
-          class="mb-10 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-slate-600 dark:bg-slate-800"
+          class="mb-10 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
         >
           <h2
-            class="mb-4 text-lg font-semibold text-zinc-800 dark:text-slate-100"
+            class="mb-4 text-lg font-semibold text-zinc-800 dark:text-neutral-200"
           >
             Guidelines
           </h2>
           <ul
-            class="space-y-2 text-sm leading-relaxed text-zinc-600 dark:text-slate-300"
+            class="space-y-2 text-sm leading-relaxed text-zinc-600 dark:text-neutral-300"
           >
             <li class="flex gap-2">
               <span class="text-green-500">&#10003;</span>
@@ -169,7 +169,7 @@ const seoDescription =
         <div class="text-center">
           <a
             href="https://github.com/nirus/coder-rocks"
-            class="inline-flex items-center gap-2 rounded-full bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-sky-600 dark:hover:bg-sky-500"
+            class="inline-flex items-center gap-2 rounded-full bg-zinc-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-cyan-600 dark:hover:bg-cyan-500"
           >
             Open the content repo &rarr;
           </a>

--- a/src/pages/topics/[tag].astro
+++ b/src/pages/topics/[tag].astro
@@ -74,29 +74,32 @@ const jsonLd = [
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <TopBarNav />
 
     <main
-      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-slate-900 dark:to-slate-800"
+      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-neutral-950 dark:to-neutral-900"
     >
       <article class="mx-auto max-w-6xl px-4">
         <div class="mb-10 text-center">
-          <nav class="mb-4 text-sm text-zinc-400 dark:text-slate-500">
-            <a href="/topics" class="hover:text-sky-600 dark:hover:text-sky-400"
-              >Topics</a
+          <nav class="mb-4 text-sm text-zinc-400 dark:text-neutral-500">
+            <a
+              href="/topics"
+              class="hover:text-sky-600 dark:hover:text-cyan-400">Topics</a
             >
             <span class="mx-1.5">/</span>
-            <span class="text-zinc-600 dark:text-slate-300">{displayName}</span>
+            <span class="text-zinc-600 dark:text-neutral-300"
+              >{displayName}</span
+            >
           </nav>
           <h1
-            class="text-2xl font-semibold tracking-tight text-zinc-800 capitalize dark:text-slate-100"
+            class="text-2xl font-semibold tracking-tight text-zinc-800 capitalize dark:text-neutral-200"
           >
             {displayName}
           </h1>
-          <p class="mt-1.5 text-sm text-zinc-400 dark:text-slate-500">
+          <p class="mt-1.5 text-sm text-zinc-400 dark:text-neutral-500">
             {posts.length}
             {posts.length === 1 ? 'article' : 'articles'}
           </p>
@@ -118,7 +121,7 @@ const jsonLd = [
         <div class="mt-10 text-center">
           <a
             href="/topics"
-            class="inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-sky-600 dark:text-slate-500 dark:hover:text-sky-400"
+            class="inline-flex items-center gap-1.5 text-sm text-zinc-400 transition-colors hover:text-sky-600 dark:text-neutral-500 dark:hover:text-cyan-400"
           >
             &larr; All topics
           </a>

--- a/src/pages/topics/index.astro
+++ b/src/pages/topics/index.astro
@@ -47,13 +47,13 @@ const jsonLd = collectionPageJsonLd({
   </head>
 
   <body
-    class="font-body personality-casual bg-white leading-normal text-black dark:bg-slate-900 dark:text-slate-100"
+    class="font-body personality-casual bg-white leading-normal text-black dark:bg-neutral-950 dark:text-neutral-200"
     data-pagefind-ignore="all"
   >
     <TopBarNav />
 
     <main
-      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-slate-900 dark:to-slate-800"
+      class="bg-gradient-to-b from-zinc-50 to-white py-12 dark:from-neutral-950 dark:to-neutral-900"
     >
       <article class="mx-auto max-w-4xl px-4">
         <div class="mb-10 text-center">
@@ -62,7 +62,7 @@ const jsonLd = collectionPageJsonLd({
           >
             Topics
           </h1>
-          <p class="mt-2 text-zinc-500 dark:text-slate-400">
+          <p class="mt-2 text-zinc-500 dark:text-neutral-400">
             Browse articles by subject
           </p>
         </div>
@@ -72,12 +72,12 @@ const jsonLd = collectionPageJsonLd({
             sortedTags.map(([slug, { display, count }]) => (
               <a
                 href={`/topics/${slug}`}
-                class="group inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-5 py-2.5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md dark:border-slate-600 dark:bg-slate-800 dark:hover:border-sky-500"
+                class="group inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-white px-5 py-2.5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-cyan-500"
               >
-                <span class="text-sm font-medium text-zinc-700 capitalize group-hover:text-sky-600 dark:text-slate-200 dark:group-hover:text-sky-400">
+                <span class="text-sm font-medium text-zinc-700 capitalize group-hover:text-sky-600 dark:text-neutral-200 dark:group-hover:text-cyan-400">
                   {display}
                 </span>
-                <span class="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-zinc-100 px-1.5 text-xs font-semibold text-zinc-500 group-hover:bg-sky-100 group-hover:text-sky-700 dark:bg-slate-700 dark:text-slate-400 dark:group-hover:bg-sky-900 dark:group-hover:text-sky-300">
+                <span class="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-zinc-100 px-1.5 text-xs font-semibold text-zinc-500 group-hover:bg-sky-100 group-hover:text-sky-700 dark:bg-neutral-800 dark:text-neutral-400 dark:group-hover:bg-cyan-900 dark:group-hover:text-cyan-300">
                   {count}
                 </span>
               </a>

--- a/src/styles/code.css
+++ b/src/styles/code.css
@@ -11,7 +11,7 @@
   ul li > code,
   ol li *:not(pre) code,
   ol li > code {
-    @apply rounded-md bg-stone-200 px-2 py-1 align-baseline font-mono text-sm leading-none text-stone-800 dark:bg-slate-700 dark:text-slate-200;
+    @apply rounded-md bg-stone-200 px-2 py-1 align-baseline font-mono text-sm leading-none text-stone-800 dark:bg-neutral-800 dark:text-neutral-200;
   }
 }
 

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -41,7 +41,7 @@
   }
 
   > p {
-    @apply mb-6 text-lg leading-normal text-stone-700 dark:text-slate-300;
+    @apply mb-6 text-lg leading-normal text-stone-700 dark:text-neutral-300;
   }
 
   > blockquote {
@@ -57,11 +57,11 @@
   }
 
   a {
-    @apply font-normal underline text-sky-600 dark:text-sky-400;
+    @apply font-normal underline text-sky-600 dark:text-cyan-400;
     text-decoration: none;
 
     &:hover {
-      @apply border-b-2 border-gray-800 text-black dark:border-slate-300 dark:text-slate-100;
+      @apply border-b-2 border-gray-800 text-black dark:border-neutral-400 dark:text-neutral-200;
     }
   }
 
@@ -92,7 +92,7 @@
   }
 
   table {
-    @apply mb-8 w-full border-collapse text-left text-sm border-2 border-black dark:border-slate-500;
+    @apply mb-8 w-full border-collapse text-left text-sm border-2 border-black dark:border-neutral-800;
 
     th {
       @apply border-t-4 border-b p-4 text-xl font-bold;

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -5,16 +5,16 @@
   a {
     font-weight: bold;
     text-decoration: underline;
-    @apply text-sky-600 dark:text-sky-400;
+    @apply text-sky-600 dark:text-cyan-400;
 
     &:hover {
-      @apply text-black dark:text-slate-100;
+      @apply text-black dark:text-neutral-200;
     }
   }
 }
 
 #searchBox {
-  @apply border-2 border-black rounded dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100;
+  @apply border-2 border-black rounded dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200;
 }
 
 .search-result-page {

--- a/src/styles/logo.css
+++ b/src/styles/logo.css
@@ -1,7 +1,7 @@
 /** Coder Rocks logo */
 h1.coder-rocks-head-title {
   font-family: 'Cutive Mono', monospace !important;
-  @apply my-2 mb-0 border-b-2 border-neutral-200 text-center text-3xl leading-[1.2] font-extrabold tracking-tighter md:text-4xl lg:text-4xl dark:border-slate-600;
+  @apply my-2 mb-0 border-b-2 border-neutral-200 text-center text-3xl leading-[1.2] font-extrabold tracking-tighter md:text-4xl lg:text-4xl dark:border-neutral-800;
 }
 
 p.coder-rocks-tagline {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -8,9 +8,9 @@
 }
 
 .dark {
-  --logo-primary: #e2e8f0;
-  --logo-secondary: #cbd5e1;
-  --logo-accent: #94a3b8;
+  --logo-primary: #e0e0e0;
+  --logo-secondary: #a8a8a8;
+  --logo-accent: #9ca3af;
 }
 
 @theme {

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -8,7 +8,7 @@
 ## theme.ts
 
 Dark mode management for client-side `<script>` tags:
-- `getStoredTheme()` / `setStoredTheme()` — localStorage key: `theme-preference`, default: `'light'`
+- `getStoredTheme()` / `setStoredTheme()` — localStorage key: `theme-preference`, default: `'dark'`
 - `toggleTheme(current)` — light ↔ dark
 - `applyTheme(pref)` — adds/removes `dark` class on `document.documentElement`
 

--- a/src/utils/theme.test.ts
+++ b/src/utils/theme.test.ts
@@ -21,8 +21,8 @@ describe('theme utilities', () => {
   })
 
   describe('getStoredTheme', () => {
-    it('returns "light" when localStorage is empty', () => {
-      expect(getStoredTheme()).toBe('light')
+    it('returns "dark" when localStorage is empty', () => {
+      expect(getStoredTheme()).toBe('dark')
     })
 
     it('returns "dark" when stored preference is dark', () => {
@@ -35,9 +35,9 @@ describe('theme utilities', () => {
       expect(getStoredTheme()).toBe('light')
     })
 
-    it('migrates legacy "system" value to "light"', () => {
+    it('defaults unknown values to "dark"', () => {
       localStorage.setItem('theme-preference', 'system')
-      expect(getStoredTheme()).toBe('light')
+      expect(getStoredTheme()).toBe('dark')
     })
   })
 

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -4,10 +4,10 @@ const STORAGE_KEY = 'theme-preference'
 
 export function getStoredTheme(): ThemePreference {
   if (typeof localStorage === 'undefined') {
-    return 'light'
+    return 'dark'
   }
   const stored = localStorage.getItem(STORAGE_KEY)
-  return stored === 'dark' ? 'dark' : 'light'
+  return stored === 'light' ? 'light' : 'dark'
 }
 
 export function setStoredTheme(theme: ThemePreference): void {


### PR DESCRIPTION
## Summary

- **Dark theme is now the default** — new visitors see dark mode; light mode is opt-in via the floating toggle button
- **Dark palette rewritten** from cool blue-grey (slate) to warm neutral editorial palette (neutral-950/900/800) with cyan accents
- **Ambient glow** on blog post articles (desktop only) — soft teal + purple backlight effect behind the content card
- **DEBUG.md expanded** with local dev/testing guide and Cloudflare preview deployment workflow

## Test plan

- [ ] Open site in incognito — should default to dark theme (no localStorage)
- [ ] Click floating sun icon — switches to light, persists on reload
- [ ] Clear localStorage `theme-preference` — defaults back to dark
- [ ] No FOUC on hard reload in dark mode
- [ ] Blog post page shows ambient glow behind article on desktop, not on mobile
- [ ] Light theme retains sky-blue accents, dark theme uses cyan accents
- [ ] All pages render correctly: `/`, `/posts/`, `/posts/<slug>`, `/search`, `/submit`, `/topics/`