### PR TITLE
chore: fix header to top with content-only scrollbar

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Syncing content repo..."
+yarn pub-code:clean && yarn pub-code:link

--- a/src/components/Navigation/TopBar.astro
+++ b/src/components/Navigation/TopBar.astro
@@ -35,7 +35,7 @@ const links: Links = [
 ]
 ---
 
-<nav class="top-nav-bar bg-zinc-800">
+<nav class="top-nav-bar fixed top-0 right-0 left-0 z-50 bg-zinc-800">
   <div
     class="mx-auto flex h-14 max-w-4xl items-center justify-between px-3 py-3"
   >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,2 +1,58 @@
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* ─── Design tokens ─── */
+:root {
+  --header-height: calc(var(--spacing) * 14);
+  --scrollbar-width: 8px;
+  --scrollbar-radius: 9999px;
+
+  /* Scrollbar colors — light */
+  --scrollbar-thumb: #d4d4d4;
+  --scrollbar-thumb-hover: #a3a3a3;
+  --scrollbar-track: transparent;
+}
+
+.dark {
+  /* Scrollbar colors — dark */
+  --scrollbar-thumb: #404040;
+  --scrollbar-thumb-hover: #525252;
+}
+
+/* ─── Fixed header layout ─── */
+html {
+  height: 100%;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+body {
+  height: calc(100% - var(--header-height));
+  height: calc(100dvh - var(--header-height));
+  margin-top: var(--header-height);
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+}
+
+/* ─── Custom scrollbar ─── */
+body {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+body::-webkit-scrollbar {
+  width: var(--scrollbar-width);
+}
+
+body::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+body::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: var(--scrollbar-radius);
+}
+
+body::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+}


### PR DESCRIPTION
## Summary
- Fix nav bar to the top of the viewport and scope the page scrollbar to the content area below it (scrollbar no longer overlaps the header)
- Use `100dvh` units for correct behavior on mobile/tablet (dynamic viewport height accounts for collapsing address bars)
- Add CSS custom properties derived from Tailwind's `--spacing` scale for header height and scrollbar styling
- Add `post-merge` git hook to auto-sync content repo on `git pull`

## Test plan
- [ ] Verify header stays fixed on scroll across all pages
- [ ] Verify scrollbar only appears in the content area, not behind the header
- [ ] Test on mobile Safari / Chrome (address bar collapse)
- [ ] Verify dark mode scrollbar colors
- [ ] Run `git pull` and confirm content repo syncs automatically