### PR TITLE
fix: compact header on mobile to reclaim vertical space

### DIFF
--- a/src/components/Navigation/TopBar.astro
+++ b/src/components/Navigation/TopBar.astro
@@ -37,7 +37,7 @@ const links: Links = [
 
 <nav class="top-nav-bar fixed top-0 right-0 left-0 z-50 bg-zinc-800">
   <div
-    class="mx-auto flex h-14 max-w-4xl items-center justify-between px-3 py-3"
+    class="mx-auto flex h-10 max-w-4xl items-center justify-between px-3 py-2 md:h-14 md:py-3"
   >
     {
       links.map(item => {
@@ -48,7 +48,7 @@ const links: Links = [
             class="flex flex-row text-center align-middle text-slate-50"
           >
             <Icon class="h-5 w-5 lg:h-6 lg:w-6" />
-            <span class="link-text">{item.name}</span>
+            <span class="link-text hidden sm:inline">{item.name}</span>
           </a>
         )
       })

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,7 +3,7 @@
 
 /* ─── Design tokens ─── */
 :root {
-  --header-height: calc(var(--spacing) * 14);
+  --header-height: calc(var(--spacing) * 10);
   --scrollbar-width: 8px;
   --scrollbar-radius: 9999px;
 
@@ -11,6 +11,12 @@
   --scrollbar-thumb: #d4d4d4;
   --scrollbar-thumb-hover: #a3a3a3;
   --scrollbar-track: transparent;
+}
+
+@media (min-width: 768px) {
+  :root {
+    --header-height: calc(var(--spacing) * 14);
+  }
 }
 
 .dark {


### PR DESCRIPTION
## Summary
- Reduce nav height from `h-14` (56px) to `h-10` (40px) on mobile, restoring `h-14` at `md:` breakpoint
- Hide link text below `sm:` breakpoint — icon-only nav on small screens
- Update `--header-height` CSS variable with responsive media query to keep body offset in sync

## Test plan
- [ ] Verify compact header on mobile viewport (<768px)
- [ ] Verify full header with text labels on tablet/desktop (≥768px)
- [ ] Verify content is not hidden behind header at both breakpoints
- [ ] Verify scrollbar starts below header at both sizes