### PR TITLE
feat: animated expand/collapse hint on theme toggle

### DIFF
--- a/src/components/Navigation/ThemeToggle.astro
+++ b/src/components/Navigation/ThemeToggle.astro
@@ -5,44 +5,54 @@
 <button
   id="theme-toggle"
   type="button"
-  class="fixed right-6 bottom-6 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-zinc-300 bg-zinc-100 shadow-lg transition-colors hover:bg-zinc-200 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:bg-neutral-800"
+  class="theme-toggle-collapsed fixed right-6 bottom-6 z-50 flex h-11 items-center overflow-hidden rounded-full border border-zinc-300 bg-zinc-100 shadow-lg transition-all duration-700 ease-in-out hover:bg-zinc-200 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:bg-neutral-800"
   aria-label="Toggle theme"
 >
-  <!-- Sun icon (shown in dark mode — click to go light) -->
-  <svg
-    id="icon-sun"
-    class="hidden h-5 w-5 text-amber-400"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
+  <span class="flex h-11 w-11 shrink-0 items-center justify-center">
+    <!-- Sun icon (shown in dark mode — click to go light) -->
+    <svg
+      id="icon-sun"
+      class="hidden h-5 w-5 text-amber-400"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+      ></path>
+    </svg>
+    <!-- Moon icon (shown in light mode — click to go dark) -->
+    <svg
+      id="icon-moon"
+      class="hidden h-5 w-5 text-zinc-700"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+      ></path>
+    </svg>
+  </span>
+  <span
+    id="theme-label"
+    class="pr-4 text-sm font-medium whitespace-nowrap text-zinc-700 transition-all duration-700 dark:text-neutral-300"
+    >Switch theme</span
   >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-    ></path>
-  </svg>
-  <!-- Moon icon (shown in light mode — click to go dark) -->
-  <svg
-    id="icon-moon"
-    class="hidden h-5 w-5 text-zinc-700"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-    ></path>
-  </svg>
 </button>
 
 <script is:inline>
   ;(function () {
     var STORAGE_KEY = 'theme-preference'
+    var HINT_KEY = 'theme-hint-shown'
+    var EXPAND_DELAY = 500
+    var COLLAPSE_DELAY = 5000
 
     function getStored() {
       var val = localStorage.getItem(STORAGE_KEY)
@@ -60,7 +70,9 @@
     function updateIcon(pref) {
       var sun = document.getElementById('icon-sun')
       var moon = document.getElementById('icon-moon')
-      if (!sun || !moon) return
+      if (!sun || !moon) {
+        return
+      }
 
       sun.classList.add('hidden')
       moon.classList.add('hidden')
@@ -78,14 +90,29 @@
     function init() {
       updateIcon(current)
       var btn = document.getElementById('theme-toggle')
-      if (btn) {
-        btn.addEventListener('click', function () {
-          current = current === 'light' ? 'dark' : 'light'
-          localStorage.setItem(STORAGE_KEY, current)
-          apply(current)
-          updateIcon(current)
-        })
+      if (!btn) {
+        return
       }
+
+      var hintShown = sessionStorage.getItem(HINT_KEY)
+
+      if (!hintShown) {
+        setTimeout(function () {
+          btn.classList.remove('theme-toggle-collapsed')
+        }, EXPAND_DELAY)
+
+        setTimeout(function () {
+          btn.classList.add('theme-toggle-collapsed')
+          sessionStorage.setItem(HINT_KEY, '1')
+        }, EXPAND_DELAY + COLLAPSE_DELAY)
+      }
+
+      btn.addEventListener('click', function () {
+        current = current === 'light' ? 'dark' : 'light'
+        localStorage.setItem(STORAGE_KEY, current)
+        apply(current)
+        updateIcon(current)
+      })
     }
 
     if (document.readyState === 'loading') {
@@ -95,3 +122,25 @@
     }
   })()
 </script>
+
+<style is:global>
+  #theme-toggle {
+    max-width: 12rem;
+  }
+
+  #theme-label {
+    opacity: 1;
+    max-width: 10rem;
+    padding-right: 1rem;
+  }
+
+  .theme-toggle-collapsed {
+    max-width: 2.75rem;
+  }
+
+  .theme-toggle-collapsed #theme-label {
+    opacity: 0;
+    max-width: 0;
+    padding-right: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Theme toggle starts collapsed (icon-only), animates open on first visit showing "Switch theme" text for 5 seconds, then collapses back
- Uses `sessionStorage` so hint resets per browser session (clears on tab close, persists across same-site navigation)
- Both expand and collapse are smooth CSS transitions via `max-width` + `opacity`
- Icon stays centered in both states via a fixed `w-11` wrapper

## Test plan
- [ ] First visit: toggle expands after 500ms, shows "Switch theme" for 5s, collapses
- [ ] Navigate to another page: toggle stays collapsed
- [ ] Close tab and reopen: hint shows again
- [ ] Click toggle: theme switches correctly in both states
- [ ] Verify dark/light mode icon swap